### PR TITLE
No need to use map in void context.

### DIFF
--- a/lib/Business/CPI/Gateway/PayPal/IPN.pm
+++ b/lib/Business/CPI/Gateway/PayPal/IPN.pm
@@ -23,13 +23,7 @@ has vars => (
     is      => 'lazy',
     default => sub {
         my $self = shift;
-
-        my $query = $self->query;
-        my %vars;
-
-        map { $vars{$_} = $query->param($_) } $query->param;
-
-        return \%vars;
+        return { map { $_ => $self->query->param($_) } $self->query->param };
     },
 );
 


### PR DESCRIPTION
Using map in void context is a bit confusing as a for/foreach loop would do the same thing.  This small commit fixes that.
